### PR TITLE
Handle the x86/x86_64 split when downloading setup.ini

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -119,7 +119,7 @@ function getsetup()
       mv setup setup.ini
       echo Updated setup.ini
     else
-      wget -N $mirror/setup.ini
+      wget -N $mirror/$arch/setup.ini
       if test -e setup.ini && test $? -eq 0
       then
         echo Updated setup.ini


### PR DESCRIPTION
Cygwin recently introduced an x86_64 version and so all the mirrors
now have x86 or x86_64 in their paths, depending on which version
you've installed.

The only change required is when the setup file is fetched.

The setup file itself contains the paths prefixed with either
x86 or x86_64
