### PR TITLE
Update for new mirror site structure

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -3,19 +3,19 @@
 # apt-cyg: install tool for cygwin similar to debian apt-get
 
 # The MIT License (MIT)
-# 
+#
 # Copyright (c) 2013 Trans-code Design
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,7 +23,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-# 
+#
 
 # this script requires some packages
 
@@ -50,7 +50,7 @@ function usage()
   echo "  \"apt-cyg describe <patterns>\" to describe packages matching patterns"
   echo "  \"apt-cyg packageof <commands or files>\" to locate parent packages"
   echo "Options:"
-  echo "  --mirror, -m <url> : set mirror"
+  echo "  --mirror, -m <url> : set mirror (Need x86/x86_64 at the end)"
   echo "  --cache, -c <dir>  : set cache"
   echo "  --file, -f <file>  : read package names from file"
   echo "  --noupdate, -u     : don't update setup.ini from mirror"
@@ -72,45 +72,51 @@ function version()
 function findworkspace()
 {
   # default working directory and mirror
-  
+
   mirror=ftp://mirror.mcs.anl.gov/pub/cygwin
+  arch=x86_64
   cache=/setup
-  
+
   # work wherever setup worked last, if possible
-  
+
   if test -e /etc/setup/last-cache
   then
     tmp="`head -1 /etc/setup/last-cache`"
     cache="`cygpath -au "$tmp"`"
   fi
-  
+
+  if test -e /etc/setup/last-arch
+  then
+    arch="`head -1 /etc/setup/last-arch`"
+  fi
+
   if test -e /etc/setup/last-mirror
   then
     mirror="`head -1 /etc/setup/last-mirror`"
   fi
   mirrordir="`echo "$mirror" | sed -e "s/:/%3a/g" -e "s:/:%2f:g"`"
-  
+
   echo Working directory is $cache
-  echo Mirror is $mirror
+  echo Mirror is $mirror, Architecture is $arch
   mkdir -p "$cache/$mirrordir"
   cd "$cache/$mirrordir"
 }
 
 
-function getsetup() 
+function getsetup()
 {
   if test "$noscripts" == "0" -a "$noupdate" == "0"
   then
     touch setup.ini
     mv setup.ini setup.ini-save
-    wget -N $mirror/setup.bz2
+    wget -N $mirror/$arch/setup.bz2
     if test -e setup.bz2 && test $? -eq 0
     then
       bunzip2 setup.bz2
       mv setup setup.ini
       echo Updated setup.ini
     else
-      wget -N $mirror/setup.ini
+      wget -N $mirror/$arch/setup.ini
       if test -e setup.ini && test $? -eq 0
       then
         echo Updated setup.ini
@@ -148,7 +154,14 @@ do
   case "$1" in
 
     --mirror|-m)
-      echo "$2" > /etc/setup/last-mirror
+      arch=`basename $2`
+      if [[ ! "$arch" =~ x86 ]];then
+        echo "Need /x86 (for 32 bit) or /x86_64 (for 64 bit) at the end of site ULR."
+        exit 1
+      fi
+      mirror=`dirname $2`
+      echo "$mirror" > /etc/setup/last-mirror
+      echo "$arch" > /etc/setup/last-arch
       shift ; shift
     ;;
 
@@ -322,8 +335,8 @@ case "$command" in
     mkdir -p "release/$pkg"
     cat setup.ini | awk > "release/$pkg/desc" -v package="$pkg" \
       'BEGIN{RS="\n\n@ "; FS="\n"} {if ($1 == package) {desc = $0; px++}} \
-       END {if (px == 1 && desc != "") print desc; else print "Package not found"}' 
-    
+       END {if (px == 1 && desc != "") print desc; else print "Package not found"}'
+
     desc=`cat "release/$pkg/desc"`
     if test "-$desc-" = "-Package not found-"
     then
@@ -336,7 +349,7 @@ case "$command" in
     # download and unpack the bz2 file
 
     # pick the latest version, which comes first
-    install=`cat "release/$pkg/desc" | awk '/^install: / { print $2; exit }'` 
+    install=`cat "release/$pkg/desc" | awk '/^install: / { print $2; exit }'`
 
     if test "-$install-" = "--"
     then
@@ -347,36 +360,36 @@ case "$command" in
     file=`basename $install`
     cd "release/$pkg"
     wget -nc $mirror/$install
-    
+
     # check the md5
-    digest=`cat "desc" | awk '/^install: / { print $4; exit }'` 
+    digest=`cat "desc" | awk '/^install: / { print $4; exit }'`
     digactual=`md5sum $file | awk '{print $1}'`
     if ! test $digest = $digactual
     then
       echo MD5 sum did not match, exiting
       exit 1
     fi
-    
+
     echo "Unpacking..."
     cat $file | bunzip2 | tar > "/etc/setup/$pkg.lst" xvf - -C /
     gzip -f "/etc/setup/$pkg.lst"
     cd ../..
-    
-    
+
+
     # update the package database
-    
+
     cat /etc/setup/installed.db | awk > /tmp/awk.$$ -v pkg="$pkg" -v bz=$file \
       '{if (ins != 1 && pkg < $1) {print pkg " " bz " 0"; ins=1}; print $0} \
        END{if (ins != 1) print pkg " " bz " 0"}'
     mv /etc/setup/installed.db /etc/setup/installed.db-save
     mv /tmp/awk.$$ /etc/setup/installed.db
-    
-    
+
+
     # recursively install required packages
-    
+
     echo > /tmp/awk.$$ '/^requires: / {s=gensub("(requires: )?([^ ]+) ?", "\\2 ", "g", $0); print s}'
     requires=`cat "release/$pkg/desc" | awk -f /tmp/awk.$$`
-    
+
     warn=0
     if ! test "-$requires-" = "--"
     then
@@ -398,9 +411,9 @@ case "$command" in
     then
       echo "Warning: some required packages did not install, continuing"
     fi
-    
+
     # run all postinstall scripts
-    
+
     pis=`ls /etc/postinstall/*.sh 2>/dev/null | wc -l`
     if test $pis -gt 0 && ! test $noscripts -eq 1
     then
@@ -411,7 +424,7 @@ case "$command" in
         mv $script $script.done
       done
     fi
-    
+
     echo Package $pkg installed
 
     done


### PR DESCRIPTION
It seems Cygwin mirror site structure has been changed.
This is update for new site structure (such setup.ini is now under architecture (x86/x86_64) directories).
