### PR TITLE
searchall fix and enhance 

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -330,7 +330,12 @@ apt-searchall () {
   cd /tmp
   for pkg in "${packages[@]}"
   do
-    printf -v qs 'text=1&arch=%s&grep=%s' $ARCH "$pkg"
+    if echo $pkg | grep "[^[:alnum:].-]"
+    then
+        printf -v qs 'text=1&arch=%s&grep=%s' $ARCH "$pkg"
+    else
+        printf -v qs 'text=1&arch=%s&grep=%s' $ARCH "$pkg.exe$"
+    fi
     wget -O matches cygwin.com/cgi-bin2/package-grep.cgi?"$qs"
     cat matches
   done


### PR DESCRIPTION
Thank you for making a useful tool. 

Is "searchall" working now?

I want use "apt-cyg searchall".
It no display out put when my env.
It make matches file but awk no output.

I  tried fix and enhance "searchall".

thanks.

my env:
Windows7Pro Japanese
32bit cygwin
$ awk --version
GNU Awk 4.1.1, API: 1.1 (GNU MPFR 3.1.2, GNU MP 6.0.0)

log:
(master) commit 8c91a53a7e86894cb21c15267d3a1836ccee27c8
$ apt-cyg searchall gcc.exe
--2014-06-25 00:00:00--  http://cygwin.com/cgi-bin2/package-grep.cgi?text=1&arch=x86&grep=gcc.exe
Resolving cygwin.com (cygwin.com)... 209.132.180.131
Connecting to cygwin.com (cygwin.com)|209.132.180.131|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [text/plain]
Saving to: 'matches'
(skip)
2014-06-25 00:00:00 (6.22 MB/s) - 'matches' saved [810]
$

(a65efc8bf02bd7572fbbdb4f91a30928e39f70c6)
$apt-cyg searchall gcc.exe
(skip)
Found 13 matches for gcc.exe
cygwin64-gcc-core-4.8.2-2 - GCC for Cygwin 64bit toolchain (C, OpenMP)
cygwin64-gcc-core-4.8.3-1 - GCC for Cygwin 64bit toolchain (C, OpenMP)
gcc-core-4.8.2-2 - GNU Compiler Collection (C, OpenMP)
gcc-core-4.8.3-1 - GNU Compiler Collection (C, OpenMP)
gcc-debuginfo-4.8.2-2 - Debug information for 
gcc-debuginfo-4.8.3-1 - Debug information for 
gcc4-core-4.7.3-2 - Obsolete package
mingw-gcc-core-4.5.2-1 - GNU Compiler Collection (C, OpenMP)
mingw-gcc-core-4.7.3-1 - GNU Compiler Collection (C, OpenMP)
mingw64-i686-gcc-core-4.8.2-1 - GNU Compiler Collection (C, OpenMP)
mingw64-i686-gcc-core-4.8.2-2 - GNU Compiler Collection (C, OpenMP)
mingw64-x86_64-gcc-core-4.8.2-1 - GNU Compiler Collection (C, OpenMP)
mingw64-x86_64-gcc-core-4.8.2-2 - GNU Compiler Collection (C, OpenMP)
