### PR TITLE
fix #453

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -450,7 +450,7 @@ function apt-install {
 function apt-remove {
   check-packages
   cd /etc
-  cygcheck awk bash bunzip2 grep gzip mv sed tar xz > setup/essential.lst
+  cygcheck awk bash bunzip2 grep gzip mv sed tar xz > setup/essential.lst 2> /dev/null
   for pkg in "${pks[@]}"
   do
 


### PR DESCRIPTION
Redirect stderr to /dev/null

$ ./apt-cyg remove nano
cygcheck: track_down: could not find api-ms-win-core-rtlsupport-l1-2-0.dll

cygcheck: track_down: could not find api-ms-win-eventing-provider-l1-1-0.dll

cygcheck: track_down: could not find api-ms-win-core-apiquery-l1-1-0.dll

cygcheck: track_down: could not find api-ms-win-core-processthreads-l1-1-2.dll

cygcheck: track_down: could not find api-ms-win-core-registry-l1-1-0.dll

cygcheck: track_down: could not find api-ms-win-core-heap-l1-2-0.dll

cygcheck: track_down: could not find api-ms-win-core-heap-l2-1-0.dll

cygcheck: track_down: could not find api-ms-win-core-memory-l1-1-2.dll
.......
