### PR TITLE
Fix #37

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -316,14 +316,14 @@ function download {
   dn=$(dirname $2)
   bn=$(basename $2)
 
-  # check the md5
+  # check the sha512 hash 
   digest=$4
   mkdir -p $cache/$mirrordir/$dn
   cd $cache/$mirrordir/$dn
-  if ! test -e $bn || ! md5sum -c <<< "$digest $bn"
+  if ! test -e $bn || ! sha512sum -c <<< "$digest $bn"
   then
     wget -O $bn $mirror/$dn/$bn
-    md5sum -c <<< "$digest $bn" || exit
+    sha512sum -c <<< "$digest $bn" || exit
   fi
 
   tar tf $bn | gzip > /etc/setup/"$pkg".lst.gz


### PR DESCRIPTION
Changed md5sum hash checking to sha512sum hash checking per issue #37 .

Cygwin documented an impending switch over to sha512 hashes in their mailing list:
```
On 10/02/15 09:39, Luke Kendall wrote:


    On 06/02/15 21:23, Corinna Vinschen wrote:
     > On Feb  6 13:05, Luke Kendall wrote:
     >> On 06/02/15 05:07, Corinna Vinschen wrote:
     >>> Hi folks,
     >>>
     >>> A new version of Setup, release 2.867, has been uploaded to
     >>>
     >>>    https://cygwin.com/setup-x86.exe     (32 bit version)
     >>>    https://cygwin.com/setup-x86_64.exe  (64 bit version)
     >>>
     >>> The changes compared to 2.864 are mostly not visible:
     >>>
     >>> - There's one fix to the output when mistyping a command line option.
     >>>
     >>> - More importantly, Setup now understands SHA512 checksums
    additionally
     >>>    to MD5 checksums.  We're going to switch to using SHA512
    checksums in
     >>>    the setup.ini files in a couple of weeks and this requires all
    of you
     >>>    to use the newer Setup version.
```
https://sourceware.org/ml/cygwin/2015-02/msg00444.html

