### PR TITLE
Add upgrade subcommand.

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -544,7 +544,7 @@ function apt-upgrade {
   do
     pks+=("$name")
     echo -n $version "=> "
-    cat /tmp/new_packages.$$ | grep "^$name " | cut -f2 -d" "
+    cat /tmp/all_packages.$$ | grep "^$name " | cut -f2 -d" "
   done < /tmp/new_packages.$$
 
   rm -f /tmp/all_packages.$$ /tmp/installed_packages.$$ /tmp/new_packages.$$

--- a/apt-cyg
+++ b/apt-cyg
@@ -48,6 +48,9 @@ OPERATIONS
     Download a fresh copy of the master package list (setup.ini) from the
     server defined in setup.rc.
 
+  upgrade
+    Upgrade all outdated package(s).
+
   download
     Retrieve package(s) from the server, but do not install/upgrade anything.
 
@@ -437,16 +440,20 @@ function apt-install {
   for pkg in "${pks[@]}"
   do
 
-  if grep -q "^$pkg " /etc/setup/installed.db
+  if [[ "$1" != "--force" ]]
   then
-    echo Package $pkg is already installed, skipping
-    continue
+    if grep -q "^$pkg " /etc/setup/installed.db
+    then
+      echo Package $pkg is already installed, skipping
+      continue
+    fi
   fi
   (( sbq++ )) && echo
   echo Installing $pkg
 
   download $pkg
   read dn bn </tmp/dwn
+  rm /tmp/dwn
   echo Unpacking...
 
   cd $cache/$mirrordir/$dn
@@ -458,7 +465,9 @@ function apt-install {
     print pkg, bz, 0
     ins = 1
   }
-  1
+  pkg != $1 {
+    print
+  }
   END {
     if (ins != 1) print pkg, bz, 0
   }
@@ -502,6 +511,55 @@ function apt-install {
   echo Package $pkg installed
 
   done
+}
+
+function apt-upgrade {
+  find-workspace
+
+  apt-update
+
+  # 0. Read setup.ini.
+  # 1. Discard [prev] and [test] version.
+  # 2. Select "@package_name" and "install: ..." line.
+  # 3. Combine "@package_name" and "install: ..." to one line.
+  # 4. Strip useless text.
+  # 5. Remove .tar.bz2 and .tar.xz filename extension.
+  # 6. Sort.
+
+  cat setup.ini | \
+    sed "/\[prev\]\|\[test\]/,/^$/d" | \
+    grep -E "@ |install: " | \
+    tr "\n" "/" | sed "s/@ /\n/g" | \
+    cut -f1-2 -d " " | awk -F/ '{print $1 " " $NF}' | \
+    sed "s/\.tar\.bz2//g; s/\.tar\.xz//g" | \
+    sort -u > /tmp/all_packages.$$
+
+  sed "1d; s/\.tar\.xz .*$//g; s/\.tar\.bz2 .*$//g" /etc/setup/installed.db | \
+    sort -u > /tmp/installed_packages.$$
+
+  comm -23 /tmp/installed_packages.$$ /tmp/all_packages.$$ > \
+    /tmp/new_packages.$$
+
+  while read name version
+  do
+    pks+=("$name")
+    echo -n $version "=> "
+    cat /tmp/new_packages.$$ | grep "^$name " | cut -f2 -d" "
+  done < /tmp/new_packages.$$
+
+  rm -f /tmp/all_packages.$$ /tmp/installed_packages.$$ /tmp/new_packages.$$
+
+  if [[ "$pks" ]]
+  then
+    echo -n "Upgrade the above packages? (Y/n) "
+    read answer
+    if [ -z "$answer" -o "$answer" = "Y" ]
+    then
+      apt-install --force
+    fi
+  else
+    echo "All packages are up to date."
+  fi
 }
 
 function apt-remove {
@@ -633,7 +691,7 @@ do
     ;;
 
     list | cache  | remove | depends | listall  | download | listfiles |\
-    show | mirror | search | install | category | rdepends | searchall )
+    show | mirror | search | install | category | rdepends | searchall | upgrade)
       if [[ $command ]]
       then
         pks+=("$1")

--- a/apt-cyg
+++ b/apt-cyg
@@ -556,6 +556,10 @@ function apt-upgrade {
     if [ -z "$answer" -o "$answer" = "Y" ]
     then
       apt-install --force
+      echo "Please manual run :" \
+        "cygstart --action=runas dash.exe" \
+        "/etc/postinstall/0p_000_autorebase.dash"
+      echo "to rebase packages if needed."
     fi
   else
     echo "All packages are up to date."


### PR DESCRIPTION
Add upgrade subcommand, to upgrade all outdated package(s).


$ ./apt-cyg upgrade
--2015-05-17 01:44:41--  http://mirrors.163.com/cygwin//x86_64/setup.bz2
Resolving mirrors.163.com (mirrors.163.com)... 123.58.173.106
Connecting to mirrors.163.com (mirrors.163.com)|123.58.173.106|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1329928 (1.3M) [application/octet-stream]
Saving to: ‘setup.bz2’

setup.bz2                                       100%[==============>]   1.27M  1.23MB/s   in 1.0s

2015-05-17 01:44:42 (1.23 MB/s) - ‘setup.bz2’ saved [1329928/1329928]

Updated setup.ini
atool-0.38.0-1 => atool-0.39.0-1
Upgrade the above packages? (Y/n)
Installing atool
atool-0.39.0-1.tar.bz2: OK
Unpacking...
Package atool requires the following packages, installing:
perl
Package perl is already installed, skipping
Package atool installed
