### PR TITLE
Allow cache directories stored in the root of the cygwin tree.

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -133,6 +133,9 @@ function find-workspace {
     print $1
   }
   ' /etc/setup/setup.rc | cygpath -f-)
+  if [[ "${cache%/}" == "${cache}" ]] ; then
+    cache="${cache}/"
+  fi
 
   mirror=$(awk '
   /last-mirror/ {
@@ -145,8 +148,8 @@ function find-workspace {
   s : %3a g
   ' <<< "$mirror")
 
-  mkdir -p "$cache/$mirrordir/$arch"
-  cd "$cache/$mirrordir/$arch"
+  mkdir -p "$cache$mirrordir/$arch"
+  cd "$cache$mirrordir/$arch"
   if [ -e setup.ini ]
   then
     return 0
@@ -375,8 +378,8 @@ function download {
    32) hash=md5sum    ;;
   128) hash=sha512sum ;;
   esac
-  mkdir -p "$cache/$mirrordir/$dn"
-  cd "$cache/$mirrordir/$dn"
+  mkdir -p "$cache$mirrordir/$dn"
+  cd "$cache$mirrordir/$dn"
   if ! test -e $bn || ! $hash -c <<< "$digest $bn"
   then
     wget -O $bn $mirror/$dn/$bn
@@ -385,7 +388,7 @@ function download {
 
   tar tf $bn | gzip > /etc/setup/"$pkg".lst.gz
   cd ~-
-  mv desc "$cache/$mirrordir/$dn"
+  mv desc "$cache$mirrordir/$dn"
   echo $dn $bn > /tmp/dwn
 }
 
@@ -445,7 +448,7 @@ function apt-install {
   read dn bn </tmp/dwn
   echo Unpacking...
 
-  cd "$cache/$mirrordir/$dn"
+  cd "$cache$mirrordir/$dn"
   tar -x -C / -f $bn
   # update the package database
 


### PR DESCRIPTION
Fixes #58.