### PR TITLE
Don't use gzip "-k" option

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -519,7 +519,7 @@ function apt-remove {
     warn Package manifest missing, cannot remove $pkg. Exiting
     exit 1
   fi
-  gzip -dk setup/"$pkg".lst.gz
+  gzip -d < setup/"$pkg".lst.gz > setup/"$pkg".lst
   awk '
   NR == FNR {
     if ($NF) ess[$NF]


### PR DESCRIPTION
This option is not available in older Cygwin versions, e.g. I'm using a (mostly frozen) Cygwin environment with gzip 1.4 that doesn't have it. It is also pretty simple to work around its lack.