### PR TITLE
Handle spaces in setup.rc last-cache setting.

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -125,12 +125,13 @@ function wget {
 
 function find-workspace {
   # default working directory and mirror
-  
+
   # work wherever setup worked last, if possible
   cache=$(awk '
+  BEGIN { FS="\t" }
   /last-cache/ {
     getline
-    print $1
+    print $2
   }
   ' /etc/setup/setup.rc)
 


### PR DESCRIPTION
My last-cache dir has a space in it and wasn't getting picked up correctly. 
This seemed to be the easiest way to correct that. 