### PR TITLE
refuse to work if bash version is < 4.2

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -607,6 +607,14 @@ function apt-cache {
   fi
 }
 
+# refuse to work on bash <4.2 
+declare -a ver
+ver=( `echo "$BASH_VERSION" | sed -rn 's/^([0-9]+)\.([0-9]+)\..*$/\1 \2/p'` )
+if [[ ${ver[0]} < 4 && ${ver[1]} < 2 ]]; then
+    warn You have bash version - $BASH_VERSION, which is not compatible with this script
+    exit 1
+fi
+
 if [ -p /dev/stdin ]
 then
   mapfile -t pks

--- a/apt-cyg
+++ b/apt-cyg
@@ -609,8 +609,9 @@ function apt-cache {
 
 # refuse to work on bash <4.2 
 declare -a ver
-ver=( `echo "$BASH_VERSION" | sed -rn 's/^([0-9]+)\.([0-9]+)\..*$/\1 \2/p'` )
-if [[ ${ver[0]} < 4 && ${ver[1]} < 2 ]]; then
+ver=( `echo "$BASH_VERSION" | sed -rn 's/^([0-9]+)\.([0-9]+)\.?.*$/\1 \2/p'` )
+if [[ ${ver[0]} -le 4 && ${ver[1]} -lt 2 ]]
+then
     warn You have bash version - $BASH_VERSION, which is not compatible with this script
     exit 1
 fi


### PR DESCRIPTION
By using -n -v we have hidden requirement for bash 4.2
I think it's better to have it in place.

And yes, the check will work incorrect on 4.05, it's not existing version as far as I know, but however. 
Any suggestions are welcome.