### PR TITLE
Bugfix when last-cache == Cygwin root dir

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -142,6 +142,7 @@ function find-workspace {
     print $2
   }
   ' /etc/setup/setup.rc)
+  cache=${cache%/} # in case it's the root
 
   mirror=$(awk '
   /last-mirror/ {


### PR DESCRIPTION
This aims to fix the following error whenever `find-workspace` is needed :
```
mkdir: could not create directory "//http%3a%2f%2fftp.snt.utwente.nl%2fpub%2fsoftware%2fcygwin%2f": Read-only file system
apt-cyg: line 149 : cd: //http%3a%2f%2fftp.snt.utwente.nl%2fpub%2fsoftware%2fcygwin%2f/x86: No such file or directory
```

Notice the `//` at the beginning of `"$cache/$mirrordir/$arch"` because `cache=/`.