### PR TITLE
fix apt-cyg URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,7 +75,7 @@ Quick start
 
 apt-cyg is a simple script. To install:
 
-    lynx -source rawgit.com/transcode-open/apt-cyg/master/apt-cyg > apt-cyg
+    lynx -source https://raw.githubusercontent.com/transcode-open/apt-cyg/master/apt-cyg > apt-cyg
     install apt-cyg /bin
 
 Example use of apt-cyg:


### PR DESCRIPTION
The old URL responds with a `301 Moved Permanently`, failing the installation instructions.

This pull request fixes the URL to the new location.
