### PR TITLE
Added curl fallback for package installation and apt-cyg installation

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -122,10 +122,15 @@ function wget {
   if command wget -h &>/dev/null
   then
     command wget "$@"
-  else
+  elif
+  then
     warn wget is not installed, using lynx as fallback
     set "${*: -1}"
     lynx -source "$1" > "${1##*/}"
+  else
+    warn wget and lynx not installed, using curl as fallback
+    set "${*: -1}"
+    curl -sL "$1" > "${1##*/}"
   fi
 }
 

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Quick start
 
 apt-cyg is a simple script. To install:
 
-    lynx -source rawgit.com/transcode-open/apt-cyg/master/apt-cyg > apt-cyg
+    curl -L rawgit.com/transcode-open/apt-cyg/master/apt-cyg > apt-cyg
     install apt-cyg /bin
 
 Example use of apt-cyg:


### PR DESCRIPTION
Current setup-x86_64.exe from the Cygwin website seems to install with
default of curl but no wget and lynx, so apt-cyg doesn't currently work
out-of-the-box and is not installable on a fresh Cygwin installation; addition
of this curl fallback should fix these two issues.