### PR TITLE
Configure Unix line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Configure Unix line endings even on Windows
+* text eol=lf


### PR DESCRIPTION
git on Windows uses auto line endings when downloading repos. We don't want bash to complain about Windows line endings, therefore we change the line endings for this repo to Unix style.